### PR TITLE
Exclude missing tag (12.2.1_git20220924), fix build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,7 @@ jobs:
       with:
         distroless_image: ghcr.io/${{ github.repository }}
         docker_image: "gcc"
+        excluded_tags: "12.2.1_git20220924"
 
     # Post to slack when things fail.
     - if: ${{ failure() }}


### PR DESCRIPTION
Relies on https://github.com/chainguard-images/actions/pull/55